### PR TITLE
Fix panic when partitioning buckets containing `T::MAX` values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,11 @@ impl<
         // Split the current layer as long as it is too large.
         if self.buckets[self.pivots.len()].len() > N {
             while self.buckets[self.pivots.len()].len() > N {
+                let prev_len = self.buckets[self.pivots.len()].len();
                 self.partition();
+                if self.buckets[self.pivots.len()].len() >= prev_len {
+                    break; // All elements equal T::MAX; no split possible.
+                }
             }
             if SORT {
                 // Sort final layer decreasing.
@@ -194,6 +198,16 @@ impl<
 
         // Sample a pivot using the pivot strategy
         let (pivot, pivot_pos) = P::pick(&cur_layer);
+
+        // When pivot == T::MAX, wrapping_add_one overflows to 0 (or T::MIN for
+        // signed types), making the first-half threshold useless. Rather than
+        // partitioning with a broken threshold, bail out immediately. The
+        // pop() loop's progress check will break and fall through to the
+        // sort-and-pop path.
+        if pivot == S::MAX {
+            return;
+        }
+
         self.pivots.push(pivot);
 
         // Reserve space in the next layer,
@@ -210,7 +224,14 @@ impl<
         // Partition a list into two using SIMD.
         let mut cur_len = 0;
         let mut next_len = 0;
-        let half = (pivot_pos + 1).min(n2).next_multiple_of(S::L);
+        // When pivot == T::MAX, wrapping_add_one overflows to 0 (or T::MIN for
+        // signed types), making the threshold useless. Skip the first half
+        // entirely so all elements use threshold = pivot.
+        let half = if pivot == S::MAX {
+            0
+        } else {
+            (pivot_pos + 1).min(n2).next_multiple_of(S::L)
+        };
         let threshold = S::splat(S::wrapping_add_one(pivot));
         for i in (0..half).step_by(S::L) {
             unsafe {
@@ -238,7 +259,7 @@ impl<
             }
         }
         if n2 < n {
-            let threshold = if pivot_pos >= n2 {
+            let threshold = if pivot_pos >= n2 && pivot != S::MAX {
                 S::splat(S::wrapping_add_one(pivot))
             } else {
                 S::splat(pivot)
@@ -256,7 +277,7 @@ impl<
             }
         }
 
-        debug_assert!(next_len > 0);
+        debug_assert!(next_len > 0 || pivot == S::MAX);
 
         unsafe {
             cur_layer.set_len(cur_len);
@@ -267,6 +288,14 @@ impl<
         // because the pivot was the largest one,
         // undo and try again.
         if cur_len == 0 {
+            std::mem::swap(cur_layer, next_layer);
+            self.pivots.pop().unwrap();
+        }
+
+        // If all elements stayed in cur_layer (next is empty), this means
+        // all elements equal T::MAX (pivot+1 overflowed or all >= pivot).
+        // Undo the partition; the pop() loop will detect no progress and stop.
+        if next_len == 0 {
             std::mem::swap(cur_layer, next_layer);
             self.pivots.pop().unwrap();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,13 @@ impl<
         // Split the current layer as long as it is too large.
         if self.buckets[self.pivots.len()].len() > N {
             while self.buckets[self.pivots.len()].len() > N {
+                let prev_depth = self.pivots.len();
                 self.partition();
+                // If partition made no progress (e.g. all elements are equal),
+                // stop splitting — the layer is fine to extract from directly.
+                if self.pivots.len() == prev_depth {
+                    break;
+                }
             }
             if SORT {
                 // Sort final layer decreasing.
@@ -256,8 +262,6 @@ impl<
             }
         }
 
-        debug_assert!(next_len > 0);
-
         unsafe {
             cur_layer.set_len(cur_len);
             next_layer.set_len(next_len);
@@ -268,6 +272,11 @@ impl<
         // undo and try again.
         if cur_len == 0 {
             std::mem::swap(cur_layer, next_layer);
+            self.pivots.pop().unwrap();
+        }
+        // If all elements stayed in cur_layer (e.g. pivot == T::MAX causing
+        // wrapping_add_one overflow), undo so the caller can detect no progress.
+        if next_len == 0 {
             self.pivots.pop().unwrap();
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -73,3 +73,31 @@ fn wiggle_avx2() {
 fn wiggle_avx512() {
     wiggle::<crate::Avx512>();
 }
+
+/// When all elements equal T::MAX and the layer
+/// exceeds N (16), partitioning uses `wrapping_add_one(T::MAX)` which wraps
+/// to 0 (for unsigned) or T::MIN (for signed). This causes all elements to
+/// be classified as "large", leaving the new bottom layer empty. The
+/// subsequent `pop` then panics on `unwrap()` of an empty layer.
+fn max_value_partition<S: SimdElem<u64>>() {
+    let mut q = <ConfigurableSimdQuickHeap<_, S>>::default();
+    // Push more than N=16 copies of u64::MAX to force partitioning on pop.
+    for _ in 0..20 {
+        q.push(u64::MAX);
+    }
+    for _ in 0..20 {
+        assert_eq!(q.pop(), Some(u64::MAX));
+    }
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn max_value_partition_avx2() {
+    max_value_partition::<crate::Avx2>();
+}
+
+#[cfg(target_feature = "avx512f")]
+#[test]
+fn max_value_partition_avx512() {
+    max_value_partition::<crate::Avx512>();
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -101,3 +101,155 @@ fn max_value_partition_avx2() {
 fn max_value_partition_avx512() {
     max_value_partition::<crate::Avx512>();
 }
+
+/// 1000 copies of u64::MAX plus one smaller value.
+/// The single smaller value must be popped first.
+fn u64_max_with_one_smaller<S: SimdElem<u64>>() {
+    let mut q = <ConfigurableSimdQuickHeap<_, S>>::default();
+    let small_val: u64 = 42;
+    for _ in 0..1000 {
+        q.push(u64::MAX);
+    }
+    q.push(small_val);
+    assert_eq!(q.pop(), Some(small_val));
+    for _ in 0..1000 {
+        assert_eq!(q.pop(), Some(u64::MAX));
+    }
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn u64_max_with_one_smaller_avx2() {
+    u64_max_with_one_smaller::<crate::Avx2>();
+}
+
+#[cfg(target_feature = "avx512f")]
+#[test]
+fn u64_max_with_one_smaller_avx512() {
+    u64_max_with_one_smaller::<crate::Avx512>();
+}
+
+/// 1000 copies of u64::MIN (0) plus one larger value.
+/// All zeros must be popped before the larger value.
+fn u64_min_with_one_larger<S: SimdElem<u64>>() {
+    let mut q = <ConfigurableSimdQuickHeap<_, S>>::default();
+    let large_val: u64 = 999;
+    for _ in 0..1000 {
+        q.push(u64::MIN);
+    }
+    q.push(large_val);
+    for _ in 0..1000 {
+        assert_eq!(q.pop(), Some(u64::MIN));
+    }
+    assert_eq!(q.pop(), Some(large_val));
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn u64_min_with_one_larger_avx2() {
+    u64_min_with_one_larger::<crate::Avx2>();
+}
+
+#[cfg(target_feature = "avx512f")]
+#[test]
+fn u64_min_with_one_larger_avx512() {
+    u64_min_with_one_larger::<crate::Avx512>();
+}
+
+/// 1000 copies of i64::MAX plus one smaller value.
+fn i64_max_with_one_smaller<S: SimdElem<i64>>() {
+    let mut q = <ConfigurableSimdQuickHeap<_, S>>::default();
+    let small_val: i64 = 7;
+    for _ in 0..1000 {
+        q.push(i64::MAX);
+    }
+    q.push(small_val);
+    assert_eq!(q.pop(), Some(small_val));
+    for _ in 0..1000 {
+        assert_eq!(q.pop(), Some(i64::MAX));
+    }
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn i64_max_with_one_smaller_avx2() {
+    i64_max_with_one_smaller::<crate::Avx2>();
+}
+
+#[cfg(target_feature = "avx512f")]
+#[test]
+fn i64_max_with_one_smaller_avx512() {
+    i64_max_with_one_smaller::<crate::Avx512>();
+}
+
+/// 1000 copies of i64::MIN plus one larger value.
+fn i64_min_with_one_larger<S: SimdElem<i64>>() {
+    let mut q = <ConfigurableSimdQuickHeap<_, S>>::default();
+    let large_val: i64 = -5;
+    for _ in 0..1000 {
+        q.push(i64::MIN);
+    }
+    q.push(large_val);
+    for _ in 0..1000 {
+        assert_eq!(q.pop(), Some(i64::MIN));
+    }
+    assert_eq!(q.pop(), Some(large_val));
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn i64_min_with_one_larger_avx2() {
+    i64_min_with_one_larger::<crate::Avx2>();
+}
+
+#[cfg(target_feature = "avx512f")]
+#[test]
+fn i64_min_with_one_larger_avx512() {
+    i64_min_with_one_larger::<crate::Avx512>();
+}
+
+/// Pure i64::MAX — all elements equal, same overflow risk as u64::MAX.
+fn i64_max_all_equal<S: SimdElem<i64>>() {
+    let mut q = <ConfigurableSimdQuickHeap<_, S>>::default();
+    for _ in 0..1000 {
+        q.push(i64::MAX);
+    }
+    for _ in 0..1000 {
+        assert_eq!(q.pop(), Some(i64::MAX));
+    }
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn i64_max_all_equal_avx2() {
+    i64_max_all_equal::<crate::Avx2>();
+}
+
+#[cfg(target_feature = "avx512f")]
+#[test]
+fn i64_max_all_equal_avx512() {
+    i64_max_all_equal::<crate::Avx512>();
+}
+
+/// Pure i64::MIN — all equal at the minimum boundary.
+fn i64_min_all_equal<S: SimdElem<i64>>() {
+    let mut q = <ConfigurableSimdQuickHeap<_, S>>::default();
+    for _ in 0..1000 {
+        q.push(i64::MIN);
+    }
+    for _ in 0..1000 {
+        assert_eq!(q.pop(), Some(i64::MIN));
+    }
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn i64_min_all_equal_avx2() {
+    i64_min_all_equal::<crate::Avx2>();
+}
+
+#[cfg(target_feature = "avx512f")]
+#[test]
+fn i64_min_all_equal_avx512() {
+    i64_min_all_equal::<crate::Avx512>();
+}


### PR DESCRIPTION
## Summary

When the bottom bucket contains more than `N` (16) elements all equal to `T::MAX` (e.g. `u64::MAX`), `pop()` panics due to an integer overflow in the partitioning threshold computation. This PR fixes the issue by detecting degenerate partitions and gracefully falling back to direct extraction.

## Root Cause

The paper describes the equal-elements handling strategy in Section 4.1:

> Elements in the bucket that are on the left of the pivot are moved down when they are *strictly* smaller than the pivot, while elements on the right of the pivot are moved down when they are *smaller or equal*.

In the implementation, "strictly smaller than pivot" is expressed as `< pivot + 1` using `wrapping_add_one`:

```rust
let threshold = S::splat(S::wrapping_add_one(pivot)); // for left-of-pivot elements
```

When `pivot == T::MAX`, `wrapping_add_one` wraps around to `T::MIN` (0 for unsigned types). The comparison `element < 0` is never true for unsigned integers, so **all** elements are classified as "large" (≥ threshold) and remain in the current bucket. The new bucket receives zero elements (`next_len == 0`).

The existing recovery logic only handles the symmetric case where `cur_len == 0` (all elements moved to the new bucket, meaning the pivot was the smallest element). The `next_len == 0` case was unhandled, resulting in:

- `debug_assert!(next_len > 0)` failure in debug builds
- An empty bottom bucket in release builds, causing `layer.pop().unwrap()` to panic

### Minimal reproduction

```rust
let mut q = SimdQuickHeap::<u64>::default();
for _ in 0..20 {  // >16 to trigger partitioning
    q.push(u64::MAX);
}
q.pop(); // panics
```

## Fix

Two changes, both in `src/lib.rs`:

**1. Handle `next_len == 0` in `partition()`** — When all elements stay in the current bucket after partitioning (the new bucket is empty), undo the partition by popping the pivot. This is the mirror of the existing `cur_len == 0` recovery. The data is already in the correct place (all elements were written back to the current bucket by the SIMD partition loops), so only the pivot needs to be removed.

**2. Detect no-progress in the `pop()` partitioning loop** — After calling `partition()`, check whether `pivots.len()` actually increased. If it didn't (partition was undone), break out of the loop. ~~This is safe because a degenerate partition means all elements in the bucket are equal, so any element is a valid minimum.~~ The existing sort and `position_min` extraction paths both handle oversized buckets correctly.

This approach is consistent with the paper's description of the discard-and-retry strategy ("if the new bucket is empty, it is discarded and a new pivot is selected"), extended to also cover the case where the *current* bucket retains all elements due to threshold overflow.

## Testing

A regression test `max_value_partition` is added that pushes 20 copies of `u64::MAX` and verifies all 20 pops return `Some(u64::MAX)` followed by `None`. Both AVX2 and AVX-512 variants are included.

## Changes

```
 src/lib.rs  | 13 +++++++++++--
 src/test.rs | 28 ++++++++++++++++++++++++++++
 2 files changed, 39 insertions(+), 2 deletions(-)
```
